### PR TITLE
fix: add the tag 'latest' to base docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-base
           tags: |
             type=raw,value=ci-${{ github.sha }}
+            type=raw,value=latest
       - uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Because the kedro and fastapi images were pulling the base image with the wrong tag

## Development notes
<!-- What have you changed, and how has this been tested? -->
added the 'latest' tag to the base image 

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added tests to cover my changes
- [ ] Ran the precommit hook
